### PR TITLE
Add Tapioca compiler view component

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,14 +49,12 @@ GEM
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    mini_portile2 (2.8.5)
     minitest (5.22.2)
     mutex_m (0.2.0)
     netrc (0.11.0)
-    nokogiri (1.16.2)
-      mini_portile2 (~> 2.8.2)
-      racc (~> 1.4)
     nokogiri (1.16.2-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.16.2-x86_64-linux)
       racc (~> 1.4)
     parallel (1.24.0)
     parser (3.3.0.5)
@@ -100,6 +98,7 @@ GEM
       sorbet-static (= 0.5.11340)
     sorbet-runtime (0.5.11340)
     sorbet-static (0.5.11340-universal-darwin)
+    sorbet-static (0.5.11340-x86_64-linux)
     sorbet-static-and-runtime (0.5.11340)
       sorbet (= 0.5.11340)
       sorbet-runtime (= 0.5.11340)
@@ -129,7 +128,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-23
-  ruby
+  x86_64-linux
 
 DEPENDENCIES
   minitest (~> 5.16)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     sorbet_erb (0.1.0)
       better_html (~> 2.0.2)
       psych
+      tapioca (~> 0.13.1)
 
 GEM
   remote: https://rubygems.org/
@@ -51,6 +52,7 @@ GEM
     mini_portile2 (2.8.5)
     minitest (5.22.2)
     mutex_m (0.2.0)
+    netrc (0.11.0)
     nokogiri (1.16.2)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
@@ -60,6 +62,7 @@ GEM
     parser (3.3.0.5)
       ast (~> 2.4.1)
       racc
+    prism (0.24.0)
     psych (5.1.2)
       stringio
     racc (1.7.3)
@@ -72,6 +75,9 @@ GEM
       nokogiri (~> 1.14)
     rainbow (3.1.1)
     rake (13.1.0)
+    rbi (0.1.10)
+      prism (>= 0.18.0, < 0.25)
+      sorbet-runtime (>= 0.5.9204)
     regexp_parser (2.9.0)
     rexml (3.2.6)
     rubocop (1.60.2)
@@ -90,10 +96,36 @@ GEM
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     smart_properties (1.17.0)
+    sorbet (0.5.11340)
+      sorbet-static (= 0.5.11340)
+    sorbet-runtime (0.5.11340)
+    sorbet-static (0.5.11340-universal-darwin)
+    sorbet-static-and-runtime (0.5.11340)
+      sorbet (= 0.5.11340)
+      sorbet-runtime (= 0.5.11340)
+    spoom (1.3.0)
+      erubi (>= 1.10.0)
+      prism (>= 0.19.0)
+      sorbet-static-and-runtime (>= 0.5.10187)
+      thor (>= 0.19.2)
     stringio (3.1.0)
+    tapioca (0.13.1)
+      bundler (>= 2.2.25)
+      netrc (>= 0.11.0)
+      parallel (>= 1.21.0)
+      rbi (>= 0.1.4, < 0.2)
+      sorbet-static-and-runtime (>= 0.5.11087)
+      spoom (>= 1.2.0)
+      thor (>= 1.2.0)
+      yard-sorbet
+    thor (1.3.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
+    yard (0.9.36)
+    yard-sorbet (0.8.1)
+      sorbet-runtime (>= 0.5)
+      yard (>= 0.9)
 
 PLATFORMS
   arm64-darwin-23

--- a/lib/tapioca/dsl/compilers/view_component_slotables.rb
+++ b/lib/tapioca/dsl/compilers/view_component_slotables.rb
@@ -1,0 +1,108 @@
+# typed: strict
+# frozen_string_literal: true
+
+return unless defined?(ViewComponent)
+
+module Tapioca
+  module Dsl
+    module Compilers
+      # Generates RBI for ViewComponent::Slotable
+      # See https://github.com/ViewComponent/view_component/blob/main/lib/view_component/slotable.rb
+      class ViewComponentSlotables < Compiler
+        extend T::Sig
+
+        ConstantType = type_member { { fixed: T.class_of(::ViewComponent::Slotable) } }
+
+        class << self
+          extend T::Sig
+
+          sig { override.returns(T::Enumerable[Module]) }
+          def gather_constants
+            all_classes
+              .select { |c| c < ViewComponent::Slotable && c.name != 'ViewComponent::Base' }
+          end
+        end
+
+        sig { override.void }
+        def decorate
+          root.create_path(constant) do |klass|
+            T.unsafe(constant).registered_slots.each do |name, config|
+              renderable_type = config[:renderable]
+              renderable = T.let(
+                case renderable_type
+                when String
+                  renderable_type
+                when Class
+                  T.must(renderable_type.name)
+                else
+                  'T.untyped'
+                end,
+                String
+              )
+
+              is_many = T.let(config[:collection], T::Boolean)
+              return_type =
+                if is_many
+                  "T::Enumerable[#{renderable}]"
+                else
+                  renderable
+                end
+
+              module_name = 'ViewComponentSlotablesMethodsModule'
+              klass.create_module(module_name) do |mod|
+                generate_instance_methods(mod, name.to_s, return_type, is_many)
+              end
+              klass.create_include(module_name)
+            end
+          end
+        end
+
+        sig { params(klass: RBI::Scope, name: String, return_type: String, is_many: T::Boolean).void }
+        def generate_instance_methods(klass, name, return_type, is_many)
+          klass.create_method(name, return_type: return_type)
+          klass.create_method("#{name}?", return_type: 'T::Boolean')
+
+          klass.create_method(
+            "with_#{name}",
+            parameters: [
+              create_rest_param('args', type: 'T.untyped'),
+              create_block_param('block', type: 'T.untyped')
+            ],
+            return_type: 'T.untyped'
+          )
+
+          if is_many
+            # For collection subcomponents, ViewComponent generates methods for the singular version
+            # of the name.
+            singular_name = ActiveSupport::Inflector.singularize(name)
+
+            klass.create_method(
+              "with_#{singular_name}",
+              parameters: [
+                create_rest_param('args', type: 'T.untyped'),
+                create_block_param('block', type: 'T.untyped')
+              ],
+              return_type: 'T.untyped'
+            )
+            klass.create_method(
+              "with_#{singular_name}_content",
+              parameters: [
+                create_param('content', type: 'T.untyped')
+              ],
+              return_type: 'T.untyped'
+            )
+
+          else
+            klass.create_method(
+              "with_#{name}_content",
+              parameters: [
+                create_param('content', type: 'T.untyped')
+              ],
+              return_type: 'T.untyped'
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/sorbet_erb.gemspec
+++ b/sorbet_erb.gemspec
@@ -33,4 +33,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'better_html', '~> 2.0.2'
   spec.add_dependency 'psych'
+  spec.add_dependency 'tapioca', '~> 0.13.1'
 end


### PR DESCRIPTION
Add a Tapioca compiler to generate shims for ViewComponent. Ideally this code would live in the ViewComponent repo, but I'll deal with upstreaming that at a later date.

It's not easy to write tests for Tapioca compilers outside of the Tapioca repo, while I've filed a bug for: https://github.com/Shopify/tapioca/issues/1865