### PR TITLE
Handle ViewComponent slot block types

### DIFF
--- a/lib/tapioca/dsl/compilers/view_component_slotables.rb
+++ b/lib/tapioca/dsl/compilers/view_component_slotables.rb
@@ -69,9 +69,12 @@ module Tapioca
             "with_#{name}",
             parameters: [
               create_rest_param('args', type: 'T.untyped'),
-              create_block_param('block', type: 'T.untyped')
+              create_block_param(
+                'block',
+                type: "T.nilable(T.proc.params(#{name}: #{return_type}).returns(T.untyped))"
+              )
             ],
-            return_type: 'T.untyped'
+            return_type: return_type
           )
 
           if is_many
@@ -101,7 +104,7 @@ module Tapioca
               parameters: [
                 create_param('content', type: 'T.untyped')
               ],
-              return_type: 'T.untyped'
+              return_type: return_type
             )
           end
         end

--- a/test/tapioca_view_component_slotables_compiler_test.rb
+++ b/test/tapioca_view_component_slotables_compiler_test.rb
@@ -82,7 +82,7 @@ class TapiocaViewComponentSlotablesCompilerTest < Minitest::Spec
             sig { returns(T::Boolean) }
             def parent?; end
 
-            sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }
+            sig { params(args: T.untyped, block: T.nilable(T.proc.params(child: T.untyped).returns(T.untyped))).returns(T.untyped) }
             def with_child(*args, &block); end
 
             sig { params(content: T.untyped).returns(T.untyped) }
@@ -107,7 +107,10 @@ class TapiocaViewComponentSlotablesCompilerTest < Minitest::Spec
       add_ruby_file('test_component.rb', <<~CONTENT)
         class TestComponent < ViewComponent::Base
           class ParentType < ViewComponent::Base; end
+          class ChildType < ViewComponent::Base; end
+
           renders_one :parent, ParentType
+          renders_many :children, ChildType
         end
       CONTENT
 
@@ -118,11 +121,26 @@ class TapiocaViewComponentSlotablesCompilerTest < Minitest::Spec
           include ViewComponentSlotablesMethodsModule
 
           module ViewComponentSlotablesMethodsModule
+            sig { returns(T::Enumerable[TestComponent::ChildType]) }
+            def children; end
+
+            sig { returns(T::Boolean) }
+            def children?; end
+
             sig { returns(TestComponent::ParentType) }
             def parent; end
 
             sig { returns(T::Boolean) }
             def parent?; end
+
+            sig { params(args: T.untyped, block: T.nilable(T.proc.params(child: TestComponent::ChildType).returns(T.untyped))).returns(TestComponent::ChildType) }
+            def with_child(*args, &block); end
+
+            sig { params(content: T.untyped).returns(T.untyped) }
+            def with_child_content(content); end
+
+            sig { params(args: T.untyped, block: T.nilable(T.proc.params(children: T::Enumerable[TestComponent::ChildType]).returns(T.untyped))).returns(T::Enumerable[TestComponent::ChildType]) }
+            def with_children(*args, &block); end
 
             sig { params(args: T.untyped, block: T.nilable(T.proc.params(parent: TestComponent::ParentType).returns(T.untyped))).returns(TestComponent::ParentType) }
             def with_parent(*args, &block); end

--- a/test/tapioca_view_component_slotables_compiler_test.rb
+++ b/test/tapioca_view_component_slotables_compiler_test.rb
@@ -88,10 +88,10 @@ class TapiocaViewComponentSlotablesCompilerTest < Minitest::Spec
             sig { params(content: T.untyped).returns(T.untyped) }
             def with_child_content(content); end
 
-            sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }
+            sig { params(args: T.untyped, block: T.nilable(T.proc.params(children: T::Enumerable[T.untyped]).returns(T.untyped))).returns(T::Enumerable[T.untyped]) }
             def with_children(*args, &block); end
 
-            sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }
+            sig { params(args: T.untyped, block: T.nilable(T.proc.params(parent: T.untyped).returns(T.untyped))).returns(T.untyped) }
             def with_parent(*args, &block); end
 
             sig { params(content: T.untyped).returns(T.untyped) }
@@ -124,10 +124,10 @@ class TapiocaViewComponentSlotablesCompilerTest < Minitest::Spec
             sig { returns(T::Boolean) }
             def parent?; end
 
-            sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }
+            sig { params(args: T.untyped, block: T.nilable(T.proc.params(parent: TestComponent::ParentType).returns(T.untyped))).returns(TestComponent::ParentType) }
             def with_parent(*args, &block); end
 
-            sig { params(content: T.untyped).returns(T.untyped) }
+            sig { params(content: T.untyped).returns(TestComponent::ParentType) }
             def with_parent_content(content); end
           end
         end
@@ -159,7 +159,7 @@ class TapiocaViewComponentSlotablesCompilerTest < Minitest::Spec
             sig { returns(T::Boolean) }
             def other_component?; end
 
-            sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }
+            sig { params(args: T.untyped, block: T.nilable(T.proc.params(other_component: T.untyped).returns(T.untyped))).returns(T.untyped) }
             def with_other_component(*args, &block); end
 
             sig { params(content: T.untyped).returns(T.untyped) }


### PR DESCRIPTION
When using [ViewComponent slots](https://viewcomponent.org/guide/slots.html), you can pass a Ruby block that takes the component itself as an argument.

This PR fixes the types that the ViewComponentSlotables compiler generates so that the block signatures aren't just `T.untyped`. In particular:
- Add the right param type for the block, and the overall return type for the slot method (e.g. `with_NAME`)
- Make the block nilable since it may not be passed

I also added some tests for the `renders_many` case to ensure those signatures are generated correctly too.