### PR TITLE
Add support for ViewComponent polymorphic slots

### DIFF
--- a/lib/tapioca/dsl/compilers/view_component_slotables.rb
+++ b/lib/tapioca/dsl/compilers/view_component_slotables.rb
@@ -35,7 +35,7 @@ module Tapioca
               module_name = 'ViewComponentSlotablesMethodsModule'
               klass.create_module(module_name) do |mod|
                 if config[:renderable_hash]
-                  generate_polymorphic_instance_methods(mod, name.to_s, config[:renderable_hash], false)
+                  generate_polymorphic_instance_methods(mod, name.to_s, config[:renderable_hash], is_many)
                 else
                   return_type = renderable_to_type_name(config[:renderable])
 
@@ -68,11 +68,19 @@ module Tapioca
           ).void
         end
         def generate_polymorphic_instance_methods(klass, slot_name, underlying_types, is_many)
+          # We want to signularize the slot name since it's used as the namespace
+          singular_slot_name =
+            if is_many
+              ActiveSupport::Inflector.singularize(slot_name)
+            else
+              slot_name
+            end
+
           klass.create_method(slot_name, return_type: 'T.untyped') # TODO: should this be T.any of underlying types?
           klass.create_method("#{slot_name}?", return_type: 'T::Boolean')
 
           underlying_types.each do |name, config|
-            namespaced_name = "#{slot_name}_#{name}"
+            namespaced_name = "#{singular_slot_name}_#{name}"
             return_type = renderable_to_type_name(config[:renderable])
 
             klass.create_method(

--- a/lib/tapioca/dsl/compilers/view_component_slotables.rb
+++ b/lib/tapioca/dsl/compilers/view_component_slotables.rb
@@ -47,13 +47,13 @@ module Tapioca
           end
         end
 
-        sig { params(r: T.untyped).returns(String) }
-        def renderable_to_type_name(r)
-          case r
+        sig { params(input: T.untyped).returns(String) }
+        def renderable_to_type_name(input)
+          case input
           when String
-            r
+            input
           when Class
-            T.must(r.name)
+            T.must(input.name)
           else
             'T.untyped'
           end

--- a/test/tapioca_view_component_slotables_compiler_test.rb
+++ b/test/tapioca_view_component_slotables_compiler_test.rb
@@ -165,7 +165,7 @@ class TapiocaViewComponentSlotablesCompilerTest < Minitest::Spec
             button: ButtonType,
           }
 
-          renders_one :visual, types: {
+          renders_many :visuals, types: {
             link: {
               renders: LinkType,
             },
@@ -190,10 +190,10 @@ class TapiocaViewComponentSlotablesCompilerTest < Minitest::Spec
             def action?; end
 
             sig { returns(T.untyped) }
-            def visual; end
+            def visuals; end
 
             sig { returns(T::Boolean) }
-            def visual?; end
+            def visuals?; end
 
             sig { params(args: T.untyped, block: T.untyped).returns(TestComponent::ButtonType) }
             def with_action_button(*args, &block); end


### PR DESCRIPTION
ViewComponent supports polymorphic slots, which are declared via a hash syntax: https://viewcomponent.org/guide/slots.html#polymorphic-slots

This PR adds support for polymorphic slots and generates the corresponding Sorbet signatures with the right underlying types.

cc @jshirley 