### PR TITLE
sorbet_erb.gemspec: bump minimum ruby version to 3.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,9 @@ AllCops:
 Style/Documentation:
   Enabled: false
 
+Style/HashSyntax:
+  Enabled: false
+
 Style/StringLiterals:
   Enabled: true
   EnforcedStyle: single_quotes

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 3.0.0
+  TargetRubyVersion: 3.1.0
 
 Style/Documentation:
   Enabled: false

--- a/sorbet_erb.gemspec
+++ b/sorbet_erb.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.summary = 'Extracts Ruby code from ERB files for Sorbet'
   spec.description = 'Extracts Ruby code from ERB files so you can run Sorbet over them'
   spec.homepage = 'https://github.com/franklinhu/sorbet_erb'
-  spec.required_ruby_version = '>= 3.0.0'
+  spec.required_ruby_version = '>= 3.1.0'
 
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'
 


### PR DESCRIPTION
We need to bump to Ruby 3.1 to be able to upgrade Tapioca

https://github.com/franklinhu/sorbet_erb/security/dependabot/9