### PR TITLE
Add support for ViewComponents

### DIFF
--- a/lib/tapioca/dsl/compilers/view_component_slotables.rb
+++ b/lib/tapioca/dsl/compilers/view_component_slotables.rb
@@ -98,7 +98,7 @@ module Tapioca
         def generate_instance_methods(klass, name, return_type, is_many)
           return_type_maybe_plural =
             if is_many
-              "T::Enumerable[#{return_type}]"
+              "T::Array[#{return_type}]"
             else
               return_type
             end

--- a/test/tapioca_view_component_slotables_compiler_test.rb
+++ b/test/tapioca_view_component_slotables_compiler_test.rb
@@ -70,7 +70,7 @@ class TapiocaViewComponentSlotablesCompilerTest < Minitest::Spec
           include ViewComponentSlotablesMethodsModule
 
           module ViewComponentSlotablesMethodsModule
-            sig { returns(T::Enumerable[T.untyped]) }
+            sig { returns(T::Array[T.untyped]) }
             def children; end
 
             sig { returns(T::Boolean) }
@@ -88,7 +88,7 @@ class TapiocaViewComponentSlotablesCompilerTest < Minitest::Spec
             sig { params(content: T.untyped).returns(T.untyped) }
             def with_child_content(content); end
 
-            sig { params(args: T.untyped, block: T.nilable(T.proc.params(children: T::Enumerable[T.untyped]).returns(T.untyped))).returns(T::Enumerable[T.untyped]) }
+            sig { params(args: T.untyped, block: T.nilable(T.proc.params(children: T::Array[T.untyped]).returns(T.untyped))).returns(T::Array[T.untyped]) }
             def with_children(*args, &block); end
 
             sig { params(args: T.untyped, block: T.nilable(T.proc.params(parent: T.untyped).returns(T.untyped))).returns(T.untyped) }
@@ -121,7 +121,7 @@ class TapiocaViewComponentSlotablesCompilerTest < Minitest::Spec
           include ViewComponentSlotablesMethodsModule
 
           module ViewComponentSlotablesMethodsModule
-            sig { returns(T::Enumerable[TestComponent::ChildType]) }
+            sig { returns(T::Array[TestComponent::ChildType]) }
             def children; end
 
             sig { returns(T::Boolean) }
@@ -139,7 +139,7 @@ class TapiocaViewComponentSlotablesCompilerTest < Minitest::Spec
             sig { params(content: T.untyped).returns(T.untyped) }
             def with_child_content(content); end
 
-            sig { params(args: T.untyped, block: T.nilable(T.proc.params(children: T::Enumerable[TestComponent::ChildType]).returns(T.untyped))).returns(T::Enumerable[TestComponent::ChildType]) }
+            sig { params(args: T.untyped, block: T.nilable(T.proc.params(children: T::Array[TestComponent::ChildType]).returns(T.untyped))).returns(T::Array[TestComponent::ChildType]) }
             def with_children(*args, &block); end
 
             sig { params(args: T.untyped, block: T.nilable(T.proc.params(parent: TestComponent::ParentType).returns(T.untyped))).returns(TestComponent::ParentType) }

--- a/test/test_sorbet_erb.rb
+++ b/test/test_sorbet_erb.rb
@@ -12,17 +12,17 @@ class TestSorbetErb < Minitest::Test
       {
         name: 'no directory',
         path: Pathname.new('app/components/my_component.html.erb'),
-        expected: 'MyComponent'
+        expected: ['MyComponent', false]
       },
       {
         name: 'component with component directory',
         path: Pathname.new('app/components/my_component/my_component.html.erb'),
-        expected: 'MyComponent'
+        expected: ['MyComponent', false]
       },
       {
         name: 'namespaced directory',
         path: Pathname.new('app/components/namespace/my_component.html.erb'),
-        expected: 'Namespace::MyComponent'
+        expected: ['Namespace::MyComponent', false]
       }
     ]
     test_cases.each do |tc|

--- a/test/test_sorbet_erb.rb
+++ b/test/test_sorbet_erb.rb
@@ -6,4 +6,28 @@ class TestSorbetErb < Minitest::Test
   def test_that_it_has_a_version_number
     refute_nil ::SorbetErb::VERSION
   end
+
+  def test_extract_class_name
+    test_cases = [
+      {
+        name: 'no directory',
+        path: Pathname.new('app/components/my_component.html.erb'),
+        expected: 'MyComponent'
+      },
+      {
+        name: 'component with component directory',
+        path: Pathname.new('app/components/my_component/my_component.html.erb'),
+        expected: 'MyComponent'
+      },
+      {
+        name: 'namespaced directory',
+        path: Pathname.new('app/components/namespace/my_component.html.erb'),
+        expected: 'Namespace::MyComponent'
+      }
+    ]
+    test_cases.each do |tc|
+      actual = SorbetErb.class_name_from_path(tc[:path])
+      assert_equal(tc[:expected], actual, tc[:name])
+    end
+  end
 end


### PR DESCRIPTION
The ERB templates for ViewComponents expect to be able to access instance variables and methods on the component class. We need to generate the RBI for these differently, namely:
- Use the class name of the component (including module namespace)
- Don't extend ApplicationController

To do this, we parse the class symbol name from the file path.

This also includes a small change to switch the ViewComponentSlotables to use Array rather than Enumerable for slot methods

r? @jshirley 