### PR TITLE
Fix release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,5 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: ruby
       - uses: rubygems/release-gem@v1
 


### PR DESCRIPTION
- Remove unnecessary ruby-version from release script (it will default to .ruby-version)