### PR TITLE
Fix exclude_paths predicate so exclusions actually match

### DIFF
--- a/lib/sorbet_erb.rb
+++ b/lib/sorbet_erb.rb
@@ -86,7 +86,7 @@ module SorbetErb
     input_dir_to_paths.each do |d, p|
       pathname = Pathname.new(p)
 
-      next if exclude_paths.any? { |p| p.include?(pathname.to_s) }
+      next if exclude_paths.any? { |excluded| pathname.to_s.include?(excluded) }
 
       extractor = CodeExtractor.new
       lines, locals, locals_sig = extractor.extract(File.read(p))

--- a/test/test_sorbet_erb.rb
+++ b/test/test_sorbet_erb.rb
@@ -19,11 +19,13 @@ class TestSorbetErb < Minitest::Test
         File.write('app/views/excluded/show.html.erb', '<div></div>')
         File.write(
           '.sorbet_erb.yml',
-          YAML.dump({ 
-            'input_dirs' => ['app'], 
-            'output_dir' => 'out',
-            'exclude_paths' => ['app/views/excluded'],
-          }),
+          YAML.dump(
+            {
+              'input_dirs' => ['app'],
+              'output_dir' => 'out',
+              'exclude_paths' => ['app/views/excluded']
+            }
+          )
         )
 
         SorbetErb.extract_rb_from_erb(nil, nil)
@@ -43,7 +45,15 @@ class TestSorbetErb < Minitest::Test
         FileUtils.mkdir_p('app/views/b')
         File.write('app/views/a/show.html.erb', '<div></div>')
         File.write('app/views/b/show.html.erb', '<div></div>')
-        File.write('.sorbet_erb.yml', "input_dirs:\n  - app\noutput_dir: out\n")
+        File.write(
+          '.sorbet_erb.yml',
+          YAML.dump(
+            {
+              'input_dirs' => ['app'],
+              'output_dir' => 'out'
+            }
+          )
+        )
 
         SorbetErb.extract_rb_from_erb(nil, nil)
 

--- a/test/test_sorbet_erb.rb
+++ b/test/test_sorbet_erb.rb
@@ -2,10 +2,51 @@
 # frozen_string_literal: true
 
 require 'test_helper'
+require 'tmpdir'
+require 'fileutils'
 
 class TestSorbetErb < Minitest::Test
   def test_that_it_has_a_version_number
     refute_nil ::SorbetErb::VERSION
+  end
+
+  def test_exclude_paths_skips_matching_files
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        FileUtils.mkdir_p('app/views/included')
+        FileUtils.mkdir_p('app/views/excluded')
+        File.write('app/views/included/show.html.erb', '<div></div>')
+        File.write('app/views/excluded/show.html.erb', '<div></div>')
+        File.write(
+          '.sorbet_erb.yml',
+          "input_dirs:\n  - app\noutput_dir: out\nexclude_paths:\n  - app/views/excluded\n"
+        )
+
+        SorbetErb.extract_rb_from_erb(nil, nil)
+
+        assert File.exist?('out/views/included/show.html.erb.generated.rb'),
+               'expected included file to be generated'
+        refute File.exist?('out/views/excluded/show.html.erb.generated.rb'),
+               'expected excluded file to be skipped'
+      end
+    end
+  end
+
+  def test_exclude_paths_empty_includes_everything
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        FileUtils.mkdir_p('app/views/a')
+        FileUtils.mkdir_p('app/views/b')
+        File.write('app/views/a/show.html.erb', '<div></div>')
+        File.write('app/views/b/show.html.erb', '<div></div>')
+        File.write('.sorbet_erb.yml', "input_dirs:\n  - app\noutput_dir: out\n")
+
+        SorbetErb.extract_rb_from_erb(nil, nil)
+
+        assert File.exist?('out/views/a/show.html.erb.generated.rb')
+        assert File.exist?('out/views/b/show.html.erb.generated.rb')
+      end
+    end
   end
 
   def test_extract_class_name

--- a/test/test_sorbet_erb.rb
+++ b/test/test_sorbet_erb.rb
@@ -19,7 +19,11 @@ class TestSorbetErb < Minitest::Test
         File.write('app/views/excluded/show.html.erb', '<div></div>')
         File.write(
           '.sorbet_erb.yml',
-          "input_dirs:\n  - app\noutput_dir: out\nexclude_paths:\n  - app/views/excluded\n"
+          YAML.dump({ 
+            input_dirs: ["app"], 
+            output_dir: "out",
+            exclude_paths: ["app/views/excluded"],
+          }),
         )
 
         SorbetErb.extract_rb_from_erb(nil, nil)

--- a/test/test_sorbet_erb.rb
+++ b/test/test_sorbet_erb.rb
@@ -20,9 +20,9 @@ class TestSorbetErb < Minitest::Test
         File.write(
           '.sorbet_erb.yml',
           YAML.dump({ 
-            input_dirs: ["app"], 
-            output_dir: "out",
-            exclude_paths: ["app/views/excluded"],
+            'input_dirs' => ['app'], 
+            'output_dir' => 'out',
+            'exclude_paths' => ['app/views/excluded'],
           }),
         )
 


### PR DESCRIPTION
Currently the `exclude_paths` option does nothing. The issue is that the predicate checking for for the path substring was inverted. I fixed the issue, and had Claude write some tests.