### PR TITLE
Update better_html dependency to allow 2.2.0 (the final version)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     sorbet_erb (0.6.0.pre.unreleased)
-      better_html (~> 2.1.1)
+      better_html (>= 2.1.1)
       psych
       tapioca (>= 0.17)
 

--- a/sorbet_erb.gemspec
+++ b/sorbet_erb.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'better_html', '~> 2.1.1'
+  spec.add_dependency 'better_html', '>= 2.1.1'
   spec.add_dependency 'psych'
   spec.add_dependency 'tapioca', '>= 0.17'
 end


### PR DESCRIPTION
Currently the gemfile locks us into `better_html 2.1.1`, but the latest ([and final](https://github.com/Shopify/better-html)) version is 2.2.0