### PR TITLE
Add 'controller_class' descriptor for ERB files

### DIFF
--- a/lib/sorbet_erb.rb
+++ b/lib/sorbet_erb.rb
@@ -90,7 +90,7 @@ module SorbetErb
       next if exclude_paths.any? { |excluded| pathname.to_s.include?(excluded) }
 
       extractor = CodeExtractor.new
-      lines, locals, locals_sig = extractor.extract(File.read(p))
+      lines, locals, locals_sig, controller_class = extractor.extract(File.read(p))
 
       # Partials and Turbo streams must use strict locals
       next if requires_defined_locals?(pathname.basename.to_s) && locals.nil? && skip_missing_locals
@@ -99,6 +99,7 @@ module SorbetErb
       locals_sig ||= ''
 
       class_name, extend_app_controller = class_name_from_path(pathname)
+      parent_class = controller_class || config.app_controller_class
 
       rel_output_dir = File.join(
         output_dir,
@@ -114,7 +115,7 @@ module SorbetErb
       File.open(output_path, 'w') do |f|
         result = erb.result_with_hash(
           class_name: class_name,
-          class_decl_suffix: extend_app_controller ? " < #{config.app_controller_class}" : '',
+          class_decl_suffix: extend_app_controller ? " < #{parent_class}" : '',
           locals: locals,
           locals_sig: locals_sig,
           extra_includes: config.extra_includes,

--- a/lib/sorbet_erb/code_extractor.rb
+++ b/lib/sorbet_erb/code_extractor.rb
@@ -9,7 +9,11 @@ module SorbetErb
   class CodeExtractor
     extend T::Sig
 
-    sig { params(input: String).returns([T::Array[String], T.nilable(String), T.nilable(String)]) }
+    sig do
+      params(input: String).returns(
+        [T::Array[String], T.nilable(String), T.nilable(String), T.nilable(String)]
+      )
+    end
     def extract(input)
       buffer = Parser::Source::Buffer.new('(buffer)')
       buffer.source = input
@@ -17,7 +21,7 @@ module SorbetErb
 
       p = CodeProcessor.new
       p.process(parser.ast)
-      [p.output, p.locals, p.locals_sig]
+      [p.output, p.locals, p.locals_sig, p.controller_class]
     end
   end
 
@@ -27,6 +31,7 @@ module SorbetErb
 
     LOCALS_PREFIX = 'locals:'
     LOCALS_SIG_PREFIX = 'locals_sig:'
+    CONTROLLER_CLASS_PREFIX = 'controller_class:'
 
     sig { returns(T::Array[String]) }
     attr_accessor :output
@@ -37,11 +42,15 @@ module SorbetErb
     sig { returns(T.nilable(String)) }
     attr_accessor :locals_sig
 
+    sig { returns(T.nilable(String)) }
+    attr_accessor :controller_class
+
     sig { void }
     def initialize
       @output = T.let([], T::Array[String])
       @locals = T.let(nil, T.nilable(String))
       @locals_sig = T.let(nil, T.nilable(String))
+      @controller_class = T.let(nil, T.nilable(String))
     end
 
     sig { params(node: AST::Node).void }
@@ -61,13 +70,15 @@ module SorbetErb
       indicator = indicator_node.children.first
       case indicator
       when '#'
-        # Ignore comments if it's not strict locals
+        # Ignore comments unless they declare a recognized annotation.
         code_text = code_node.children.first.strip
         if code_text.start_with?(LOCALS_PREFIX)
           # No need to parse the locals
           @locals = code_text.delete_prefix(LOCALS_PREFIX).strip
         elsif code_text.start_with?(LOCALS_SIG_PREFIX)
           @locals_sig = code_text.delete_prefix(LOCALS_SIG_PREFIX).strip
+        elsif code_text.start_with?(CONTROLLER_CLASS_PREFIX)
+          @controller_class = code_text.delete_prefix(CONTROLLER_CLASS_PREFIX).strip
         end
       else
         process_all(node.children)

--- a/test/code_extractor_test.rb
+++ b/test/code_extractor_test.rb
@@ -84,11 +84,47 @@ class CodeExtractorTest < Minitest::Spec
         ],
         locals: '(a:, b:)',
         locals_sig: 'sig { params(a: Integer, b: String).void }'
+      },
+      {
+        name: 'controller_class annotation',
+        input: <<~INPUT,
+          <%# controller_class: MyBaseController %>
+          <%= @something %>
+        INPUT
+        output: [
+          ' @something '
+        ],
+        locals: nil,
+        controller_class: 'MyBaseController'
+      },
+      {
+        name: 'controller_class annotation with no space',
+        input: <<~INPUT,
+          <%# controller_class:UserMailer %>
+          <%= @something %>
+        INPUT
+        output: [
+          ' @something '
+        ],
+        locals: nil,
+        controller_class: 'UserMailer'
+      },
+      {
+        name: 'controller_class with namespaced class',
+        input: <<~INPUT,
+          <%# controller_class: MyNamespace::MyMailer %>
+          <%= @something %>
+        INPUT
+        output: [
+          ' @something '
+        ],
+        locals: nil,
+        controller_class: 'MyNamespace::MyMailer'
       }
     ]
     test_cases.each do |tc|
       e = SorbetErb::CodeExtractor.new
-      actual, locals, locals_sig = e.extract(tc[:input])
+      actual, locals, locals_sig, controller_class = e.extract(tc[:input])
       assert_equal(tc[:output], actual, tc[:name])
       if tc[:locals].nil?
         assert_nil(locals, tc[:name])
@@ -100,6 +136,12 @@ class CodeExtractorTest < Minitest::Spec
         assert_nil(locals_sig, tc[:name])
       else
         assert_equal(tc[:locals_sig], locals_sig, tc[:name])
+      end
+
+      if tc[:controller_class].nil?
+        assert_nil(controller_class, tc[:name])
+      else
+        assert_equal(tc[:controller_class], controller_class, tc[:name])
       end
     end
   end

--- a/test/test_sorbet_erb.rb
+++ b/test/test_sorbet_erb.rb
@@ -63,6 +63,46 @@ class TestSorbetErb < Minitest::Test
     end
   end
 
+  def test_controller_class_annotation_overrides_default_parent
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        FileUtils.mkdir_p('app/views/employees')
+        File.write(
+          'app/views/employees/show.html.erb',
+          "<%# controller_class: MyBaseController %>\n<div></div>\n"
+        )
+        File.write('.sorbet_erb.yml', YAML.dump({ 'input_dirs' => ['app'], 'output_dir' => 'out' }))
+
+        SorbetErb.extract_rb_from_erb(nil, nil)
+
+        out = File.read('out/views/employees/show.html.erb.generated.rb')
+        assert_match(/class SorbetErb\w+ < MyBaseController/, out)
+      end
+    end
+  end
+
+  def test_controller_class_annotation_overrides_app_controller_class_config
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        FileUtils.mkdir_p('app/views/users')
+        File.write(
+          'app/views/users/show.html.erb',
+          "<%# controller_class: UserMailer %>\n<div></div>\n"
+        )
+        File.write(
+          '.sorbet_erb.yml',
+          YAML.dump({ 'input_dirs' => ['app'], 'output_dir' => 'out', 'app_controller_class' => 'CustomBase' })
+        )
+
+        SorbetErb.extract_rb_from_erb(nil, nil)
+
+        out = File.read('out/views/users/show.html.erb.generated.rb')
+        assert_match(/class SorbetErb\w+ < UserMailer/, out)
+        refute_match(/CustomBase/, out)
+      end
+    end
+  end
+
   def test_app_controller_class_override
     Dir.mktmpdir do |dir|
       Dir.chdir(dir) do


### PR DESCRIPTION
Adds the ability to specify the controller class for ERBs, which improves the Sorbet types generated. The descriptor comment at the top of the ERB file looks like this:

```
<%# controller_class: EmployeesController %>
```

which results in generated code that looks like
```
class SorbetErb11f7dcbe17fc < EmployeesController
```