### PR TITLE
gemspec: ship only runtime files, shrinking the gem by 99% (1.71 MB → 10 KB)

### DIFF
--- a/sorbet_erb.gemspec
+++ b/sorbet_erb.gemspec
@@ -23,8 +23,6 @@ Gem::Specification.new do |spec|
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  # Opt-in filter: only ship runtime code and docs. In particular this excludes the
-  # ~11 MB of development-only `sorbet/rbi` files that are not needed at runtime.
   spec.files = Dir.chdir(__dir__) do
     `git ls-files -z`.split("\x0").select do |f|
       f.start_with?('lib/', 'exe/', 'sig/') ||

--- a/sorbet_erb.gemspec
+++ b/sorbet_erb.gemspec
@@ -23,10 +23,12 @@ Gem::Specification.new do |spec|
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
+  # Opt-in filter: only ship runtime code and docs. In particular this excludes the
+  # ~11 MB of development-only `sorbet/rbi` files that are not needed at runtime.
   spec.files = Dir.chdir(__dir__) do
-    `git ls-files -z`.split("\x0").reject do |f|
-      (File.expand_path(f) == __FILE__) ||
-        f.start_with?(*%w[bin/ test/ spec/ features/ .git .github appveyor Gemfile])
+    `git ls-files -z`.split("\x0").select do |f|
+      f.start_with?('lib/', 'exe/', 'sig/') ||
+        %w[README.md LICENSE].include?(f)
     end
   end
   spec.bindir = 'exe'


### PR DESCRIPTION
Hi Franklin! 👋 Thanks so much for building and maintaining `sorbet_erb`. It's a genuinely useful gem. I hope you're doing well. It's been a while since our time at Stripe together.

## Summary

The published `.gem` was **1.71 MB** even though the runtime code is only ~650 lines across four files. The bloat came from packaging the entire `sorbet/rbi/` directory (~11 MB on disk, 107 development-only gem RBI files) into the gem.

This switches the `spec.files` filter from opt-out (`reject`) to opt-in (`select`), so the gem ships only what's needed at runtime:

- `lib/`
- `exe/`
- `sig/`
- `README.md`
- `LICENSE`

## Impact

| | Before | After |
|---|---|---|
| Built `.gem` size | 1.71 MB (1,787,904 bytes) | 10 KB (10,240 bytes) |

**99.43% reduction** in `.gem` file size.

## Verification

Built the gem both ways and confirmed the contents are exactly the runtime files:

```
LICENSE
README.md
exe/sorbet_erb
lib/sorbet_erb.rb
lib/sorbet_erb/code_extractor.rb
lib/sorbet_erb/version.rb
lib/tapioca/dsl/compilers/view_component_slotables.rb
sig/sorbet_erb.rbs
```

Note: RubyGems always packages the gemspec itself into the gem regardless of `spec.files`, so dropping it from the opt-in list is fine. The `bindir`/`executables` logic is unaffected since `exe/sorbet_erb` is still included.
